### PR TITLE
Removed server control from client interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,14 @@ Or install it yourself as:
 
 ## Usage
 
-### Default behaviour: self managed VLC instance
-
 ```ruby
 
 vlc = VLC::Client.new
 => #<VLC::Client:0x00000000c21be0 @host="localhost", @port=9595, @auto_start=true, @headless=true, @process=#<IO:fd 5>, @socket=#<TCPSocket:fd 6>>
 
-vlc.running?
-=> true
+vlc.play('http://example.org/media.mp3') #play media
 ```
 
-### VLC instance management bypass
-
-```ruby
-vlc = VLC::Client.new(auto_start: false)
-=> #<VLC::Client:0x00000001a73f90 @auto_start=false, @headless=true, @host="localhost", @port=9595>
-
-vlc.running?
-=> false
-```
 
 ## Reference
 

--- a/lib/vlc-client.rb
+++ b/lib/vlc-client.rb
@@ -18,6 +18,7 @@ module VLC
 
     attr_reader   :host,
                   :port,
+                  :server,
                   :auto_start
 
     # Creates a connection to VLC media player
@@ -42,35 +43,6 @@ module VLC
         @server.start
         retryable(:tries => 3, :on => VLC::ConnectionRefused) { connect }
       end
-    end
-
-    # Queries if VLC is running
-    #
-    # @return [Boolean] true is VLC is running, false otherwise
-    #
-    def running?
-      @server.running?
-    end
-
-    alias :started? :running?
-
-    # Starts a VLC instance in a subprocess
-    #
-    # @return [Integer] the subprocess PID or nil if the start command
-    #                     as no effect (e.g. VLC already running)
-    #
-    def start
-      @server.start
-    end
-
-    # Starts a VLC instance in a subprocess
-    #
-    # @return [Integer] the terminated subprocess PID or nil if the stop command
-    #                     as no effect (e.g. VLC not running)
-    #
-    def stop
-      disconnect
-      @server.stop
     end
 
     # Connects to VLC RC interface on Client#host and Client#port

--- a/lib/vlc-client/server.rb
+++ b/lib/vlc-client/server.rb
@@ -1,6 +1,4 @@
 module VLC
-  # @private
-  #
   # Manages a local VLC server in a child process
   #
   class Server
@@ -20,6 +18,14 @@ module VLC
     def running?
       not @process.nil?
     end
+
+    alias :started? :running?
+
+    # Queries if VLC is stopped
+    #
+    # @return [Boolean] true is VLC is stopped, false otherwise
+    #
+    def stopped?; not running?; end
 
     # Starts a VLC instance in a subprocess
     #

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -4,22 +4,29 @@ describe VLC::Client do
 
     it 'starts a dedicated VLC instance by default' do
       vlc = VLC::Client.new
-      vlc.should be_running
-      vlc.should be_connected
-      vlc.stop
+      vlc.server.should be_running
+      vlc.should be_connected #auto-connect
+
+      vlc.disconnect
+      vlc.server.stop
     end
 
     it 'can disregard VLC dedicated instance' do
       vlc = VLC::Client.new(:auto_start => false)
-      vlc.should_not be_running
+      vlc.server.should_not be_running
 
-      vlc.start.should_not be_nil
-      vlc.should be_running
+      vlc.server.start.should_not be_nil
+      vlc.server.should be_running
 
-      vlc.stop.should_not be_nil
-      vlc.should_not be_started
+      vlc.server.stop.should_not be_nil
+      vlc.server.should be_stopped
       vlc.should_not be_connected
     end
+  end
+
+  it 'contains an embedded VLC server' do
+    mock_system_calls(:kill => false)
+    VLC::Client.new(:auto_start => false).server.should be_a(VLC::Server)
   end
 
   it 'is configurable' do
@@ -28,7 +35,7 @@ describe VLC::Client do
                           :port => 9999,
                           :headless => true)
 
-    vlc.should_not be_running
+    vlc.server.should_not be_running
     vlc.host.should eq('192.168.1.10')
     vlc.port.should eq(9999)
     vlc.should be_headless

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -23,15 +23,15 @@ module Mocks
     tcp
   end
 
-  def mock_system_calls
+  def mock_system_calls(opts = {})
     IO.stub(:popen).and_return do
       process = Class.new
 
-      process.should_receive(:pid).twice.and_return { 1 }
+      process.should_receive(:pid).at_least(:once).and_return { 1 }
       process
     end
 
-    Process.should_receive(:kill).once.with('INT', 1)
+    Process.should_receive(:kill).once.with('INT', 1) if opts.fetch(:kill, true)
   end
 
   def mock_sub_systems

--- a/spec/vlc-client/client/media_controls_spec.rb
+++ b/spec/vlc-client/client/media_controls_spec.rb
@@ -10,7 +10,7 @@ describe VLC::Client::MediaControls do
       vlc.play('./media.mp3')
     end
 
-    it 'from filesystem' do
+    it 'from a file descriptor' do
       File.stub(:open).and_return {
         f = File.new('./LICENSE', 'r')
         f.should_receive(:path).once.and_return('./media.mp3')


### PR DESCRIPTION
The embedded server interface is now a first class citizen so it's not
delegated to the VLC::Client interface. This server lifecycle management is
to be made directlly against the VLC::Server interface. see VLC::Client#server.
