### PR TITLE
Add a delay between connection retries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+   - gem install bundler -v 1.10
 script: bundle exec rake --verbose --trace
 bundler_args: --without development
 matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rake'
+gem 'rake', '~> 10.4.2'
 
 group :development do
   gem 'guard-rspec', '~> 2.5.1'
@@ -10,6 +10,10 @@ group :development do
 end
 
 group :test do
+  platforms :ruby_19 do
+    gem 'tins', '~> 1.6.0'
+  end
+
   gem 'mime-types',  '< 2.0.0'
   gem 'rspec',       '~> 2.14.1', :require => false
   gem 'simplecov',   '~> 0.8.2',  :require => false

--- a/lib/vlc-client.rb
+++ b/lib/vlc-client.rb
@@ -70,7 +70,8 @@ module VLC
       bind_server(server, options) unless server.nil?
     end
 
-  private
+    private
+
     def bind_server(server, options = {})
       @connection.host = server.host
       @connection.port = server.port
@@ -83,7 +84,11 @@ module VLC
         begin
           connect
         rescue VLC::ConnectionRefused => e
-          retry if (connection_calls += 1) < connection_retries
+          if (connection_calls += 1) < connection_retries
+            sleep(0.5)
+            retry
+          end
+
           @server.stop
           raise e
         end
@@ -98,19 +103,20 @@ module VLC
         @host = args.first.to_s
         @port = Integer(args.last)
       else
-        @host, @port = 'localhost', 9595
+        @host = 'localhost'
+        @port = 9595
       end
       args
     end
 
-    def media_arg(media)
+    def media(media)
       case media
       when File
         media.path
       when String, URI
         media
       else
-        raise ArgumentError, "Can not play: #{media}"
+        raise ArgumentError, "Can not play #{media}"
       end
     end
   end

--- a/lib/vlc-client/client/media_controls.rb
+++ b/lib/vlc-client/client/media_controls.rb
@@ -22,7 +22,7 @@ module VLC
       #     vlc.play #resume playback
       #
       def play(media = nil)
-        connection.write(media.nil? ? "play" : "add #{media_arg(media)}")
+        connection.write(media.nil? ? "play" : "add #{media(media)}")
       end
 
       # Pauses playback

--- a/lib/vlc-client/client/playlist_controls.rb
+++ b/lib/vlc-client/client/playlist_controls.rb
@@ -17,7 +17,7 @@ module VLC
       # @param media [String, File, URI] the media to be played
       #
       def add_to_playlist(media)
-        connection.write("enqueue #{media_arg(media)}")
+        connection.write("enqueue #{media(media)}")
       end
 
       # Lists tracks on the playlist
@@ -47,7 +47,8 @@ module VLC
         connection.write("clear")
       end
 
-    private
+      private
+
       def parse_playlist(list)
         list.map do |item|
           match = item.match(LIST_ITEM_REGEXP)

--- a/lib/vlc-client/connection.rb
+++ b/lib/vlc-client/connection.rb
@@ -19,8 +19,7 @@ module VLC
     # Connects to VLC RC interface on Client#host and Client#port
     def connect
       @socket = TCPSocket.new(@host, @port)
-      #Channel cleanup: some vlc versions echo two lines of text on connect.
-      2.times { read(0.1) rescue nil }
+      2.times { read(0.1) rescue nil } #Channel cleanup: some vlc versions echo two lines of text on connect.
       true
     rescue Errno::ECONNREFUSED => e
       raise VLC::ConnectionRefused, "Could not connect to #{@host}:#{@port}: #{e}"
@@ -31,7 +30,7 @@ module VLC
     # @return [Boolean] true is connected, false otherwise
     #
     def connected?
-      not(@socket.nil?)
+      not @socket.nil?
     end
 
     # Disconnects from VLC RC interface
@@ -52,6 +51,7 @@ module VLC
     #
     def write(data, fire_and_forget = true)
       raise NotConnectedError, "no connection to server" unless connected?
+
       @socket.puts(data)
       @socket.flush
 

--- a/lib/vlc-client/errors.rb
+++ b/lib/vlc-client/errors.rb
@@ -1,19 +1,8 @@
 module VLC
-  # Root error class
-  class Error < StandardError; end
-
-  # Raised on connection refusal
-  class ConnectionRefused < Error; end
-
-  # Raised on communication errors
-  class ProtocolError < Error; end
-
-  # Raised on a write to a broken connection
-  class BrokenConnectionError < Error; end
-
-  # Raised on a write to a disconnected connection
-  class NotConnectedError < Error; end
-
-  # Raised on a read timeout
-  class ReadTimeoutError < Error; end
+  Error                 = Class.new(StandardError) # Root error class
+  ConnectionRefused     = Class.new(Error)         # Raised on connection refusal
+  NotConnectedError     = Class.new(Error)         # Raised on a write to a disconnected connection
+  BrokenConnectionError = Class.new(Error)         # Raised on a write to a broken connection
+  ProtocolError         = Class.new(Error)         # Raised on communication errors
+  ReadTimeoutError      = Class.new(Error)         # Raised on a read timeout
 end

--- a/lib/vlc-client/system.rb
+++ b/lib/vlc-client/system.rb
@@ -38,6 +38,7 @@ module VLC
         server.host = args.first.to_s
         server.port = Integer(args.last)
       end
+
       @client = VLC::Client.new(server, opts)
     end
 
@@ -49,7 +50,8 @@ module VLC
       client.respond_to?(method, private_methods) || super(method, private_methods)
     end
 
-  protected
+    protected
+
     # Delegate to VLC::Client
     #
     def method_missing(method, *args, &block)

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -44,7 +44,7 @@ module Mocks
       Process.should_receive(:spawn).once.and_return(99)
     end
 
-    Process.should_receive(:kill).once.with('INT', 99) if opts.fetch(:kill, true)
+    Process.should_receive(:kill).once.with('SIGTERM', 99) if opts.fetch(:kill, true)
   end
 
   def mock_file(filename)


### PR DESCRIPTION
In order to avoid connection refused error due to slow starts
the System sleeps for 0.5 seconds between connection retries.
This commit also locks the CI rake and tins versions